### PR TITLE
86 create admin questions page route

### DIFF
--- a/FormFlow.Blazor/Components/Pages/Admin/AdminQuestions.razor
+++ b/FormFlow.Blazor/Components/Pages/Admin/AdminQuestions.razor
@@ -1,0 +1,16 @@
+@page "/admin/questions"
+@using MudBlazor
+
+<PageTitle>Question Management</PageTitle>
+
+
+<MudPaper Class="pa-4" Elevation="1">
+    <h3>Question Management</h3>
+
+    <p>This page will contain the admin UI for creating and managing questions.</p>
+
+    <MudButton Variant="Variant.Filled"
+                Color="Color.Primary">
+        Create New Question            
+    </MudButton>
+</MudPaper>

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -1,0 +1,71 @@
+
+# **Admin Module Documentation**
+
+## Overview
+The Admin Module provides pages and tools for managing FormFlow resources such as questions, forms, users, and submissions.  
+Each admin feature is organized under a dedicated route within the `/admin` namespace.
+
+This document grows as new admin pages are added.
+
+---
+
+# **Admin Routes**
+
+## **1. Admin Dashboard**
+**Route:**  
+```
+/admin
+```
+
+**Purpose:**  
+Landing page for the admin area. Provides navigation to all admin modules.
+
+**Status:**  
+_Not implemented yet._
+
+---
+
+## **2. Question Management**
+### **2.1 Questions List Page**
+**Route:**  
+```
+/admin/questions
+```
+
+**Purpose:**  
+Entry point for managing questions. Displays a placeholder header and a button for navigating to the question creation page.
+
+**Current Features:**
+- Loads successfully at `/admin/questions`
+- Shows header: **“Question Management”**
+- Contains a **Create New Question** button (navigation enabled once the create page exists)
+- Placeholder text describing the module
+
+**Future Enhancements:**
+- Display list of existing questions  
+- Add edit/delete actions  
+- Add search/filter  
+- Integrate with backend question API  
+
+---
+
+### **2.2 Create Question Page**
+**Route:**  
+```
+/admin/questions/create
+```
+
+**Purpose:**  
+Form for creating a new question.
+
+**Status:**  
+_Not implemented yet._  
+Button on `/admin/questions` will link here once created.
+
+**Future Enhancements:**
+- Question type selector  
+- Dynamic form fields based on type  
+- Validation  
+- Save to backend  
+
+---


### PR DESCRIPTION
# Pull Request

## Description
Adds the initial Admin Questions page at /admin/questions as the entry point for question management. Includes a placeholder header, descriptive text, and a MudBlazor-styled button for future navigation to the question creation form. Establishes the first route in the admin module and provides a foundation for expanding admin functionality.

## Related Issues
Closes #86 

## Checklist
- [x] Tests added/updated
<img width="1901" height="1177" alt="admin page" src="https://github.com/user-attachments/assets/eee65b39-43f3-4ea2-8fe3-908e8c3ae79d" />

- [x] Documentation updated
`docs/admin.md`

- [x] Linting passes