### PR TITLE
65-implement-get-endpoint-to-retrieve-a-question-by-id

### DIFF
--- a/FormFlow.Backend.Tests/Endpoints/QuestionTemplateEndpointTests.cs
+++ b/FormFlow.Backend.Tests/Endpoints/QuestionTemplateEndpointTests.cs
@@ -1,49 +1,138 @@
 using System.Net;
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Xunit;
 using FormFlow.Data.Models;
+using LiteDB;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 
 
 namespace FormFlow.Backend.Tests.Endpoints
 {
-    public class BackendFactory : WebApplicationFactory<Program>
+    public sealed class BackendFactory : WebApplicationFactory<Program>, IDisposable
     {
+        public string DatabasePath { get; } = Path.Combine(
+            Path.GetTempPath(),
+            $"formflow-endpoint-tests-{Guid.NewGuid():N}.db");
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                var existingDatabaseRegistration = services.FirstOrDefault(d => d.ServiceType == typeof(ILiteDatabase));
+                if (existingDatabaseRegistration is not null)
+                {
+                    services.Remove(existingDatabaseRegistration);
+                }
+
+                services.AddSingleton<ILiteDatabase>(_ =>
+                    new LiteDatabase($"Filename={DatabasePath};Connection=shared"));
+            });
+        }
+
+        public new void Dispose()
+        {
+            base.Dispose();
+
+            if (File.Exists(DatabasePath))
+            {
+                File.Delete(DatabasePath);
+            }
+        }
     }
 
-    public class QuestionTemplateEndpointTests : IClassFixture<BackendFactory>
+    public class QuestionByIdEndpointTests : IClassFixture<BackendFactory>
     {
+        private static readonly Guid ExistingQuestionId = new("b5d8f0e1-1c5b-4f7b-8cfa-6cab5f7fd001");
         private readonly HttpClient _client;
+        private readonly BackendFactory _factory;
 
-        public QuestionTemplateEndpointTests(BackendFactory factory)
+        public QuestionByIdEndpointTests(BackendFactory factory)
         {
+            _factory = factory;
             _client = factory.CreateClient();
         }
 
         [Fact]
-        public async Task Get_TemplateQuestion_Returns200AndValidQuestion()
+        public async Task Get_QuestionById_Returns200AndRequestedQuestion()
         {
-            var response = await _client.GetAsync("/api/questions/template");
+            EnsureKnownQuestionExists();
+
+            var response = await _client.GetAsync($"/api/questions/{ExistingQuestionId}");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             var question = await response.Content.ReadFromJsonAsync<QuestionDefinition>();
             Assert.NotNull(question);
-
-            Assert.False(string.IsNullOrWhiteSpace(question.Label));
-            Assert.False(string.IsNullOrWhiteSpace(question.Type));
-
-            //ValidationConfigs must be a non-empty JSON string
-            Assert.False(string.IsNullOrWhiteSpace(question.ValidationConfigs));
+            Assert.Equal(ExistingQuestionId, question.Id);
+            Assert.Equal("first_name", question.Key);
+            Assert.Equal("First Name", question.Label);
         }
 
         [Fact]
-        public async Task Get_TemplateQuestion_ProducesJson()
+        public async Task Get_QuestionById_Returns404WhenQuestionDoesNotExist()
         {
-            var response = await _client.GetAsync("/api/questions/template");
+            var unknownId = Guid.NewGuid();
+
+            var response = await _client.GetAsync($"/api/questions/{unknownId}");
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("not-a-guid")]
+        public async Task Get_QuestionById_Returns400ForInvalidId(string invalidId)
+        {
+            var requestPath = string.IsNullOrEmpty(invalidId)
+                ? "/api/questions/%20"
+                : $"/api/questions/{Uri.EscapeDataString(invalidId)}";
+
+            var response = await _client.GetAsync(requestPath);
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Get_QuestionById_WithEmptyDatabase_Returns404AndDoesNotThrow()
+        {
+            using (var database = new LiteDatabase($"Filename={_factory.DatabasePath};Connection=shared"))
+            {
+                database.DropCollection("questions");
+            }
+
+            var response = await _client.GetAsync($"/api/questions/{Guid.NewGuid()}");
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Get_QuestionById_ProducesJson()
+        {
+            EnsureKnownQuestionExists();
+
+            var response = await _client.GetAsync($"/api/questions/{ExistingQuestionId}");
 
             Assert.Equal("application/json; charset=utf-8",
                 response.Content.Headers.ContentType?.ToString());
+        }
+
+        private void EnsureKnownQuestionExists()
+        {
+            using var database = new LiteDatabase($"Filename={_factory.DatabasePath};Connection=shared");
+            var collection = database.GetCollection<QuestionDefinition>("questions");
+
+            collection.Upsert(new QuestionDefinition
+            {
+                Id = ExistingQuestionId,
+                Key = "first_name",
+                Label = "First Name",
+                Type = "text",
+                Required = true,
+                Placeholder = "Enter your first name"
+            });
         }
     }
 }

--- a/FormFlow.Backend/Endpoints/QuestionEndpoints.cs
+++ b/FormFlow.Backend/Endpoints/QuestionEndpoints.cs
@@ -1,5 +1,5 @@
+using FormFlow.Backend.Repositories;
 using FormFlow.Data.Models;
-using FormFlow.Backend.Templates;
 
 namespace FormFlow.Backend.Endpoints
 {
@@ -7,17 +7,29 @@ namespace FormFlow.Backend.Endpoints
     {
         public static void MapQuestionEndpoints(this IEndpointRouteBuilder app)
         {
-            app.MapGet("/api/questions/template", () =>
+            app.MapGet("/api/questions/{id}", (string id, IQuestionRepository repository) =>
             {
-                var question = SingleQuestionTemplate.Get();
+                if (string.IsNullOrWhiteSpace(id) || !Guid.TryParse(id, out var parsedId))
+                {
+                    return Results.BadRequest(new
+                    {
+                        error = "Invalid question id. Provide a non-empty GUID value."
+                    });
+                }
+
+                var question = repository.Questions.FindById(parsedId);
+
+                if (question is null)
+                {
+                    return Results.NotFound();
+                }
+
                 return Results.Json(question);
             })
-            .WithName("GetQuestionTemplate")
+            .WithName("GetQuestionById")
             .Produces<QuestionDefinition>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest)
-            .Produces(StatusCodes.Status404NotFound)
-            .Produces(StatusCodes.Status500InternalServerError)
-            .Produces(StatusCodes.Status503ServiceUnavailable);
+            .Produces(StatusCodes.Status404NotFound);
         }
     }
 }

--- a/FormFlow.Backend/README.md
+++ b/FormFlow.Backend/README.md
@@ -1,0 +1,61 @@
+# FormFlow Backend
+
+## Questions API
+
+### GET /api/questions/{id}
+
+Returns a single question document from the LiteDB `questions` collection.
+
+### Path Parameter
+
+- `id` (string, required): Question ID as a GUID.
+
+### Request Example
+
+```bash
+curl -X GET "https://localhost:7209/api/questions/b5d8f0e1-1c5b-4f7b-8cfa-6cab5f7fd001" \
+  -H "Accept: application/json"
+```
+
+### 200 OK Example
+
+```json
+{
+  "id": "b5d8f0e1-1c5b-4f7b-8cfa-6cab5f7fd001",
+  "key": "first_name",
+  "label": "First Name",
+  "type": "text",
+  "required": true,
+  "placeholder": "Enter your first name",
+  "defaultValue": null,
+  "options": [],
+  "visibleIf": null,
+  "validationConfigs": null,
+  "helpText": null
+}
+```
+
+### 400 Bad Request Example
+
+Returned when `id` is empty, whitespace, or not a valid GUID.
+
+```json
+{
+  "error": "Invalid question id. Provide a non-empty GUID value."
+}
+```
+
+### 404 Not Found
+
+Returned when the `id` is valid but no question exists with that ID.
+
+Response body is empty.
+
+### Response Content Type
+
+- `application/json` for successful responses.
+
+## Notes
+
+- This endpoint is read-only and uses `QuestionRepository`.
+- No list, create, update, or delete operations are provided here.

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,11 +22,11 @@ https://localhost:7209
 
 ---
 
-## GET `/api/questions/template`
+## GET `/api/questions/{id}`
 
-Retrieve a default template question object.
+Retrieve one question document by ID from the LiteDB `questions` collection.
 
-This endpoint is used to provide a starter question for form creation workflows.
+This endpoint is used by frontend clients to load and render real question data.
 
 ---
 
@@ -41,7 +41,13 @@ GET
 ### **URL**
 
 ```
-/api/questions/template
+/api/questions/{id}
+```
+
+Example:
+
+```
+/api/questions/b5d8f0e1-1c5b-4f7b-8cfa-6cab5f7fd001
 ```
 
 ### **Headers**
@@ -62,38 +68,43 @@ None required.
 
 | Status Code                         | Meaning                                 |
 | ----------------------------------- | --------------------------------------- |
-| **200 OK**                    | Template question returned successfully |
-| **500 Internal Server Error** | Unexpected server error                 |
+| **200 OK**                    | Question returned successfully          |
+| **400 Bad Request**           | ID is empty, whitespace, or malformed   |
+| **404 Not Found**             | No question exists for the provided ID  |
 
 ---
 
-### **Response Body (JSON)**
+### **200 Response Body (JSON)**
 
 {
-  "id": "00000000-0000-0000-0000-000000000000",
-  "key": "exampleKey",
-  "label": "Example question",
+  "id": "b5d8f0e1-1c5b-4f7b-8cfa-6cab5f7fd001",
+  "key": "first_name",
+  "label": "First Name",
   "type": "text",
   "required": true,
-  "placeholder": "Enter value",
+  "placeholder": "Enter your first name",
   "defaultValue": null,
   "options": [],
-  "visibleIf": {
-    "questionKey": null,
-    "equals": false
-  },
-  "validationConfigs": [
-    { "ValidationType": "MinLength", "MinLength": 1 },
-    { "ValidationType": "MaxLength", "MaxLength": 100},
-],
-  "helpText": "This is an example question."
+  "visibleIf": null,
+  "validationConfigs": null,
+  "helpText": null
 }
+
+### **400 Response Body (JSON)**
+
+{
+  "error": "Invalid question id. Provide a non-empty GUID value."
+}
+
+### **404 Response Body**
+
+No response body.
 
 ### **Field Descriptions**
 
 | Field                         | Type             | Description                                                                                                          |
 | ----------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `id`                        | `string(Guid)` | Unique identifier for the question. Template questions typically use an empty GUID.                                  |
+| `id`                        | `string(Guid)` | Unique identifier for the question.                                                                                  |
 | `key`                       | `string`       | Internal key used to reference this question in form submissions.                                                    |
 | `label`                     | `string`       | The text displayed to the user.                                                                                      |
 | `type`                      | `string`       | The question type (e.g.,`"text"`,`"number"`,`"dropdown"`)                                                      |
@@ -114,7 +125,7 @@ None required.
 ### **cURL**
 
 ```bash
-curl -X GET "https://localhost:7209/api/questions/template" \
+curl -X GET "https://localhost:7209/api/questions/b5d8f0e1-1c5b-4f7b-8cfa-6cab5f7fd001" \
      -H "Accept: application/json"
 ```
 
@@ -122,7 +133,7 @@ curl -X GET "https://localhost:7209/api/questions/template" \
 
 ```powershell
 Invoke-RestMethod -Method GET `
-  -Uri "https://localhost:7209/api/questions/template" `
+  -Uri "https://localhost:7209/api/questions/b5d8f0e1-1c5b-4f7b-8cfa-6cab5f7fd001" `
   -Headers @{ Accept = "application/json" }
 ```
 
@@ -132,7 +143,7 @@ Invoke-RestMethod -Method GET `
 2. Create a new **GET** request
 3. Enter the URL:
    ```
-   https://localhost:7209/api/questions/template
+  https://localhost:7209/api/questions/b5d8f0e1-1c5b-4f7b-8cfa-6cab5f7fd001
    ```
 4. Set header:
    ```
@@ -143,7 +154,7 @@ Invoke-RestMethod -Method GET `
 **Expected Response:**
 
 * Status: `200 OK`
-* Body: JSON object with `label` and `type`
+* Body: JSON object matching `QuestionDefinition`
 * Content-Type: `application/json; charset=utf-8`
 
 ---
@@ -152,12 +163,24 @@ Invoke-RestMethod -Method GET `
 
 The following integration tests validate this endpoint:
 
-### `Get_TemplateQuestion_Returns200AndValidQuestion`
+### `Get_QuestionById_Returns200AndRequestedQuestion`
 
 * Ensures the endpoint returns **200 OK**
-* Ensures the JSON body contains non‑empty `label` and `type`
+* Ensures the JSON body contains the requested question
 
-### `Get_TemplateQuestion_ProducesJson`
+### `Get_QuestionById_Returns404WhenQuestionDoesNotExist`
+
+* Ensures unknown IDs return **404 Not Found**
+
+### `Get_QuestionById_Returns400ForInvalidId`
+
+* Ensures invalid IDs return **400 Bad Request**
+
+### `Get_QuestionById_WithEmptyDatabase_Returns404AndDoesNotThrow`
+
+* Ensures empty database lookups return **404 Not Found** and do not throw exceptions
+
+### `Get_QuestionById_ProducesJson`
 
 * Ensures the response `Content-Type` is `application/json; charset=utf-8`
 
@@ -167,11 +190,11 @@ These tests run using `WebApplicationFactory<Program>` to spin up the real backe
 
 # Notes
 
-* This endpoint currently returns a static template question.
-* Future enhancements may include:
-  * Dynamic question templates
-  * Multiple question types
-  * User‑defined templates
-  * Database‑driven question generation
+* This endpoint is intentionally read-only.
+* Out of scope for this endpoint:
+  * GET all questions
+  * POST/PUT/DELETE
+  * Survey hydration
+  * Additional validation logic
 
 ---


### PR DESCRIPTION
# Pull Request

## Description
Implemented a new GET endpoint at [/api/questions/{id}](vscode-file://vscode-app/d:/VSCODE/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) that retrieves a real question from the LiteDB [questions](vscode-file://vscode-app/d:/VSCODE/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) collection using the existing [QuestionRepository](vscode-file://vscode-app/d:/VSCODE/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Added tests covering success, invalid ID, missing question, and empty database behavior, and updated the backend/API documentation with request, response, and error examples.

## Related Issues
Closes #65

## Checklist
- [ ] Tests added/updated
<img width="941" height="398" alt="image" src="https://github.com/user-attachments/assets/618c888d-e876-466d-9e8f-74203f2ff4d2" />

- [ ] Documentation updated
FormFlow.Backend/README.md
docs/api.md
- [ ] Linting passes