### PR TITLE
90-add-dynamic-option-editor

### DIFF
--- a/FormFlow.Blazor.Tests/Components/AdminCreateQuestionTests.cs
+++ b/FormFlow.Blazor.Tests/Components/AdminCreateQuestionTests.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using FluentAssertions;
 using FormFlow.Blazor.Components.Pages.Admin;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
 using MudBlazor.Services;
@@ -143,6 +144,9 @@ public class AdminCreateQuestionTests
         return ctx;
     }
 
+    private static readonly MethodInfo? _stateHasChanged =
+        typeof(ComponentBase).GetMethod("StateHasChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+
     private static async Task SetTypeAsync(IRenderedComponent<AdminCreateQuestion> cut, string type)
     {
         var typeField = typeof(AdminCreateQuestion)
@@ -154,6 +158,7 @@ public class AdminCreateQuestionTests
         {
             var question = typeField!.GetValue(cut.Instance);
             question!.GetType().GetProperty("Type")!.SetValue(question, type);
+            _stateHasChanged!.Invoke(cut.Instance, null);
         });
     }
 
@@ -165,7 +170,11 @@ public class AdminCreateQuestionTests
 
         method.Should().NotBeNull();
 
-        await cut.InvokeAsync(() => method!.Invoke(cut.Instance, null));
+        await cut.InvokeAsync(() =>
+        {
+            method!.Invoke(cut.Instance, null);
+            _stateHasChanged!.Invoke(cut.Instance, null);
+        });
     }
 
     private static async Task InvokeRemoveOptionAsync(IRenderedComponent<AdminCreateQuestion> cut, int index)
@@ -176,7 +185,11 @@ public class AdminCreateQuestionTests
 
         method.Should().NotBeNull();
 
-        await cut.InvokeAsync(() => method!.Invoke(cut.Instance, new object[] { index }));
+        await cut.InvokeAsync(() =>
+        {
+            method!.Invoke(cut.Instance, new object[] { index });
+            _stateHasChanged!.Invoke(cut.Instance, null);
+        });
     }
 
     private static async Task InvokeCreateQuestionAsync(IRenderedComponent<AdminCreateQuestion> cut)

--- a/FormFlow.Blazor.Tests/Components/AdminCreateQuestionTests.cs
+++ b/FormFlow.Blazor.Tests/Components/AdminCreateQuestionTests.cs
@@ -45,6 +45,90 @@ public class AdminCreateQuestionTests
         });
     }
 
+    [Theory]
+    [InlineData("dropdown")]
+    [InlineData("radio")]
+    [InlineData("checkbox")]
+    [InlineData("multiselect")]
+    public async Task OptionsEditor_Appears_For_OptionBasedTypes(string type)
+    {
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<AdminCreateQuestion>();
+
+        await SetTypeAsync(cut, type);
+
+        cut.WaitForAssertion(() =>
+            cut.Markup.Should().Contain("Add Option"));
+    }
+
+    [Theory]
+    [InlineData("text")]
+    [InlineData("number")]
+    [InlineData("yes_no")]
+    public async Task OptionsEditor_Hidden_For_NonOptionTypes(string type)
+    {
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<AdminCreateQuestion>();
+
+        await SetTypeAsync(cut, type);
+
+        cut.WaitForAssertion(() =>
+            cut.Markup.Should().NotContain("Add Option"));
+    }
+
+    [Fact]
+    public async Task AddOption_AddsOptionRow()
+    {
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<AdminCreateQuestion>();
+
+        await SetTypeAsync(cut, "dropdown");
+
+        cut.WaitForAssertion(() =>
+            cut.Markup.Should().Contain("Add Option"));
+
+        await InvokeAddOptionAsync(cut);
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-option-row]").Should().HaveCount(1));
+    }
+
+    [Fact]
+    public async Task RemoveOption_RemovesOptionRow()
+    {
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<AdminCreateQuestion>();
+
+        await SetTypeAsync(cut, "radio");
+
+        await InvokeAddOptionAsync(cut);
+        await InvokeAddOptionAsync(cut);
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-option-row]").Should().HaveCount(2));
+
+        await InvokeRemoveOptionAsync(cut, 0);
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-option-row]").Should().HaveCount(1));
+    }
+
+    [Fact]
+    public async Task AddOption_MultipleRows_TrackedCorrectly()
+    {
+        await using var ctx = CreateContext();
+        var cut = ctx.Render<AdminCreateQuestion>();
+
+        await SetTypeAsync(cut, "multiselect");
+
+        await InvokeAddOptionAsync(cut);
+        await InvokeAddOptionAsync(cut);
+        await InvokeAddOptionAsync(cut);
+
+        cut.WaitForAssertion(() =>
+            cut.FindAll("[data-option-row]").Should().HaveCount(3));
+    }
+
     private static BunitContext CreateContext()
     {
         var ctx = new BunitContext();
@@ -57,6 +141,42 @@ public class AdminCreateQuestionTests
         ctx.Render<MudSnackbarProvider>();
 
         return ctx;
+    }
+
+    private static async Task SetTypeAsync(IRenderedComponent<AdminCreateQuestion> cut, string type)
+    {
+        var typeField = typeof(AdminCreateQuestion)
+            .GetField("newQuestion", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        typeField.Should().NotBeNull();
+
+        await cut.InvokeAsync(() =>
+        {
+            var question = typeField!.GetValue(cut.Instance);
+            question!.GetType().GetProperty("Type")!.SetValue(question, type);
+        });
+    }
+
+    private static async Task InvokeAddOptionAsync(IRenderedComponent<AdminCreateQuestion> cut)
+    {
+        var method = typeof(AdminCreateQuestion).GetMethod(
+            "AddOption",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        method.Should().NotBeNull();
+
+        await cut.InvokeAsync(() => method!.Invoke(cut.Instance, null));
+    }
+
+    private static async Task InvokeRemoveOptionAsync(IRenderedComponent<AdminCreateQuestion> cut, int index)
+    {
+        var method = typeof(AdminCreateQuestion).GetMethod(
+            "RemoveOption",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        method.Should().NotBeNull();
+
+        await cut.InvokeAsync(() => method!.Invoke(cut.Instance, new object[] { index }));
     }
 
     private static async Task InvokeCreateQuestionAsync(IRenderedComponent<AdminCreateQuestion> cut)

--- a/FormFlow.Blazor.Tests/Components/YesNoQuestionTests.cs
+++ b/FormFlow.Blazor.Tests/Components/YesNoQuestionTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using FormFlow.Blazor.Components.QuestionTypes;
 using FormFlow.Data.Models;
 using MudBlazor.Services;
+using System.Reflection;
 using Xunit.Sdk;
 
 namespace FormFlow.Blazor.Tests.Components;

--- a/FormFlow.Blazor/Components/Pages/Admin/AdminCreateQuestion.razor
+++ b/FormFlow.Blazor/Components/Pages/Admin/AdminCreateQuestion.razor
@@ -61,6 +61,44 @@
                       Lines="3"
                       Class="mb-4" />
 
+        @if (IsOptionBasedType)
+        {
+            <MudText Typo="Typo.subtitle1" Class="mb-2">Options</MudText>
+
+            @for (int i = 0; i < newQuestion.Options.Count; i++)
+            {
+                var index = i;
+                <MudGrid Class="mb-2" data-option-row="@index">
+                    <MudItem xs="5">
+                        <MudTextField T="string"
+                                      Label="Label"
+                                      @bind-Value="newQuestion.Options[index].Label"
+                                      Immediate="true" />
+                    </MudItem>
+                    <MudItem xs="5">
+                        <MudTextField T="string"
+                                      Label="Value"
+                                      @bind-Value="newQuestion.Options[index].Value"
+                                      Immediate="true" />
+                    </MudItem>
+                    <MudItem xs="2" Class="d-flex align-center">
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                       Color="Color.Error"
+                                       aria-label="Remove option"
+                                       OnClick="() => RemoveOption(index)" />
+                    </MudItem>
+                </MudGrid>
+            }
+
+            <MudButton Variant="Variant.Outlined"
+                       Color="Color.Secondary"
+                       StartIcon="@Icons.Material.Filled.Add"
+                       OnClick="AddOption"
+                       Class="mb-4">
+                Add Option
+            </MudButton>
+        }
+
         <MudButton Variant="Variant.Filled"
                    Color="Color.Primary"
                    Disabled="@(!CanCreate)"
@@ -76,11 +114,26 @@
 
     private NewQuestion newQuestion = new();
 
+    private static readonly HashSet<string> OptionBasedTypes =
+        new(StringComparer.OrdinalIgnoreCase) { "dropdown", "radio", "checkbox", "multiselect" };
+
+    private bool IsOptionBasedType => OptionBasedTypes.Contains(newQuestion.Type);
+
     private bool CanCreate =>
         _isValid &&
         !string.IsNullOrWhiteSpace(newQuestion.Label) &&
         !string.IsNullOrWhiteSpace(newQuestion.Key) &&
         !string.IsNullOrWhiteSpace(newQuestion.Type);
+
+    private void AddOption()
+    {
+        newQuestion.Options.Add(new Option { Label = string.Empty, Value = string.Empty });
+    }
+
+    private void RemoveOption(int index)
+    {
+        newQuestion.Options.RemoveAt(index);
+    }
 
     private async Task CreateQuestion()
     {

--- a/FormFlow.Data/Models/NewQuestion.cs
+++ b/FormFlow.Data/Models/NewQuestion.cs
@@ -9,5 +9,6 @@ namespace FormFlow.Data.Models
         public string? Placeholder { get; set; }
         public string? DefaultValue { get; set; }
         public string? HelpText { get; set; }
+        public List<Option> Options { get; set; } = new();
     }
 }

--- a/docs/question-definition.md
+++ b/docs/question-definition.md
@@ -120,6 +120,79 @@ Unit tests verify that:
 
 ---
 
+## **Options Example JSON**
+
+The following examples show valid JSON structures for option-based question types. Options are required for `dropdown`, `radio`, `checkbox`, and `multiselect` types.
+
+### Dropdown
+
+```json
+{
+  "id": "a1b2c3d4-0000-0000-0000-000000000001",
+  "key": "study_level",
+  "label": "Study Level",
+  "type": "dropdown",
+  "required": true,
+  "options": [
+    { "label": "Undergraduate", "value": "undergrad" },
+    { "label": "Postgraduate", "value": "postgrad" },
+    { "label": "PhD", "value": "phd" }
+  ]
+}
+```
+
+### Radio
+
+```json
+{
+  "id": "a1b2c3d4-0000-0000-0000-000000000002",
+  "key": "contact_method",
+  "label": "Preferred Contact Method",
+  "type": "radio",
+  "required": true,
+  "options": [
+    { "label": "Email", "value": "email" },
+    { "label": "Phone", "value": "phone" },
+    { "label": "Post", "value": "post" }
+  ]
+}
+```
+
+### Multiselect
+
+```json
+{
+  "id": "a1b2c3d4-0000-0000-0000-000000000003",
+  "key": "skills",
+  "label": "Skills",
+  "type": "multiselect",
+  "required": false,
+  "options": [
+    { "label": "C#", "value": "csharp" },
+    { "label": "JavaScript", "value": "javascript" },
+    { "label": "Python", "value": "python" },
+    { "label": "SQL", "value": "sql" }
+  ]
+}
+```
+
+### Checkbox
+
+```json
+{
+  "id": "a1b2c3d4-0000-0000-0000-000000000004",
+  "key": "subscribe_newsletter",
+  "label": "Subscribe to newsletter",
+  "type": "checkbox",
+  "required": false,
+  "options": [
+    { "label": "Yes, subscribe me", "value": "yes" }
+  ]
+}
+```
+
+---
+
 ## **Usage in the System**
 
 The `QuestionDefinition` model is used by:


### PR DESCRIPTION
# Pull Request

## Description
Adds a dynamic options editor to the admin question creation form that conditionally renders for option-based question types (dropdown, radio, checkbox, multiselect). Admins can add and remove option rows, with each row exposing editable label and value fields bound to the NewQuestion.Options list. Includes bUnit tests covering editor visibility per type and add/remove behaviour, plus example JSON documentation.
<img width="494" height="422" alt="image" src="https://github.com/user-attachments/assets/ced369bb-44c7-4354-a819-924c233e664d" />

## Related Issues
Closes #90 

## Checklist
- [ ] Tests added/updated
<img width="1601" height="496" alt="image" src="https://github.com/user-attachments/assets/7aea3f23-932b-4017-b769-8521ca6f23b3" />

- [ ] Documentation updated
form-flow/docs/question-definition.md
- [ ] Linting passes