### PR TITLE
67 add a survey collection to litedb

### DIFF
--- a/FormFlow.Backend.Tests/Respositories/SurveyRepositoryTests.cs
+++ b/FormFlow.Backend.Tests/Respositories/SurveyRepositoryTests.cs
@@ -1,0 +1,87 @@
+using System;
+using FluentAssertions;
+using LiteDB;
+using Xunit;
+using FormFlow.Data.Models;
+using FormFlow.Backend.Repositories;
+
+namespace FormFlow.Backend.Tests.Repositories
+{
+    public class SurveyRepositoryTests
+    {
+        private ILiteDatabase CreateInMemoryDb()
+        {
+            return new LiteDatabase("Filename=:memory:");
+        }
+
+        [Fact]
+        public void Repository_Initializes_Surveys_Collection()
+        {
+            using var db = CreateInMemoryDb();
+            var repo = new SurveyRepository(db);
+
+            repo.Surveys.Should().NotBeNull();
+            repo.Surveys.Name.Should().Be("surveys");
+        }
+
+        [Fact]
+        public void Repository_Creates_Unique_Id_Index()
+        {
+            using var db = CreateInMemoryDb();
+            var repo = new SurveyRepository(db);
+
+            // Insert a survey
+            var survey = new SurveyDefinition
+            {
+                Id = Guid.NewGuid(),
+                Title = "Test Survey",
+                Description = "desc",
+                QuestionIds = new(),
+                CreatedAt = DateTime.UtcNow
+            };
+
+            repo.Surveys.Insert(survey);
+
+            // Attempt duplicate insert
+            Action act = () => repo.Surveys.Insert(survey);
+
+            act.Should().Throw<LiteException>();
+        }
+
+        [Fact]
+        public void Repository_Can_Insert_And_Retrieve_Survey()
+        {
+            using var db = CreateInMemoryDb();
+            var repo = new SurveyRepository(db);
+
+            var survey = new SurveyDefinition
+            {
+                Id = Guid.NewGuid(),
+                Title = "Customer Feedback",
+                Description = "Basic survey",
+                QuestionIds = [Guid.NewGuid(), Guid.NewGuid()],
+                CreatedAt = DateTime.UtcNow
+            };
+
+            repo.Surveys.Insert(survey);
+
+            var retrieved = repo.Surveys.FindById(survey.Id);
+
+            retrieved.Should().NotBeNull();
+            retrieved!.Id.Should().Be(survey.Id);
+            retrieved.Title.Should().Be("Customer Feedback");
+            retrieved.QuestionIds.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void Repository_Returns_Null_For_Missing_Survey()
+        {
+            using var db = CreateInMemoryDb();
+            var repo = new SurveyRepository(db);
+
+            var result = repo.Surveys.FindById(Guid.NewGuid());
+
+            result.Should().BeNull();
+        }
+    }
+}

--- a/FormFlow.Backend/Program.cs
+++ b/FormFlow.Backend/Program.cs
@@ -20,6 +20,7 @@ builder.Services.AddSingleton<ILiteDatabase>(sp =>
 // Register the QuestionInserter service
 builder.Services.AddSingleton<IQuestionInserter, QuestionInserter>();
 builder.Services.AddSingleton<IQuestionRepository, QuestionRepository>();
+builder.Services.AddSingleton<ISurveyRepository, SurveyRepository>();
 builder.Services.AddSingleton<QuestionValidator>();
 builder.Services.AddSingleton<DatabaseSeeder>();
 

--- a/FormFlow.Backend/Repositories/SurveyRepository.cs
+++ b/FormFlow.Backend/Repositories/SurveyRepository.cs
@@ -11,7 +11,7 @@ namespace FormFlow.Backend.Repositories
         {
             Surveys = db.GetCollection<SurveyDefinition>("surveys");
 
-            Surveys.EnsureIndex(s => s.Id);
+            Surveys.EnsureIndex(s => s.Id, true);
         }
     }
 

--- a/FormFlow.Backend/Repositories/SurveyRepository.cs
+++ b/FormFlow.Backend/Repositories/SurveyRepository.cs
@@ -1,0 +1,22 @@
+using LiteDB;
+using FormFlow.Data.Models;
+
+namespace FormFlow.Backend.Repositories
+{
+    public class SurveyRepository : ISurveyRepository
+    {
+        public ILiteCollection<SurveyDefinition> Surveys { get; }
+
+        public SurveyRepository(ILiteDatabase db)
+        {
+            Surveys = db.GetCollection<SurveyDefinition>("surveys");
+
+            Surveys.EnsureIndex(s => s.Id);
+        }
+    }
+
+    public interface ISurveyRepository
+    {
+        ILiteCollection<SurveyDefinition> Surveys { get; }
+    }
+}

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,6 +1,7 @@
- # Initial Database Reference
+# Initial Database Reference
 
- # Name of DB File:
+# Name of DB File:
+
     formflow.db
 
 # Program.cs so Far:
@@ -10,9 +11,9 @@
 
     # Questions Collection Access
 
-    The backend exposes the LiteDB `questions` collection through a repository:
+    The backend exposes the LiteDB`questions` collection through a repository:
 
-    - Repository: `FormFlow.Backend.Repositories.QuestionRepository`
+    - Repository:`FormFlow.Backend.Repositories.QuestionRepository`
     - Interface: `FormFlow.Backend.Repositories.IQuestionRepository`
     - Collection type: `ILiteCollection<QuestionDefinition>`
     - Collection name: `questions`
@@ -26,11 +27,19 @@
     {
         private readonly IQuestionRepository _questionRepository;
 
-        public SomeService(IQuestionRepository questionRepository)
+    public SomeService(IQuestionRepository questionRepository)
         {
             _questionRepository = questionRepository;
         }
     }
-    ```
-    
- 
+
+   ```
+
+# Repositories
+
+## SurveyRepository
+
+The SurveyRepository provides access to the LiteDB "surveys" collection.
+It exposes a strongly typed ILiteCollection `<SurveyDefinition>` and is registered
+in dependency injection as ISurveyRepository. This allows endpoints and services
+to store and retrieve survey documents in a consistent and structured way.


### PR DESCRIPTION
# Pull Request

## Description
Adds the SurveyRepository with a strongly typed LiteDB "surveys" collection, including unique Id indexing and DI registration to support upcoming survey CRUD endpoints.

## Related Issues
Closes #67 

## Checklist
- [x] Tests added/updated
<img width="1506" height="603" alt="tests passed" src="https://github.com/user-attachments/assets/8b143c2e-ce2b-4df5-b8e5-ea01829c99de" />

- [x] Documentation updated
`docs/database.md`

- [x] Linting passes