### PR TITLE
107 implement post surveys endpoint

### DIFF
--- a/FormFlow.Backend.Tests/Endpoints/SurveyEndpointsTests.cs
+++ b/FormFlow.Backend.Tests/Endpoints/SurveyEndpointsTests.cs
@@ -7,6 +7,7 @@ using LiteDB;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using Moq;
 
 namespace FormFlow.Backend.Tests.Endpoints;
 
@@ -96,5 +97,55 @@ public class SurveyEndpointsTests : IClassFixture<WebApplicationFactory<Program>
         var response = await client.GetAsync($"/api/surveys/{Guid.NewGuid()}");
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostSurvey_ReturnsCreated_AndPersistsSurvey()
+    {
+        // Arrange
+        var mockRepo = new Mock<ISurveyRepository>();
+
+        var mockCollection = new Mock<ILiteCollection<SurveyDefinition>>();
+
+        mockRepo.Setup(r => r.Surveys).Returns(mockCollection.Object);
+        mockRepo.Setup(r => r.Insert(It.IsAny<SurveyDefinition>()))
+                .Returns((SurveyDefinition s) => s);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                // Replace real repo with mock
+                services.AddSingleton<ISurveyRepository>(mockRepo.Object);
+            });
+        }).CreateClient();
+
+        var newSurvey = new NewSurvey
+        {
+            Title = "Test Survey",
+            Description = "A unit test survey",
+            QuestionIds = new List<Guid> { Guid.NewGuid() }
+        };
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/surveys", newSurvey);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var created = await response.Content.ReadFromJsonAsync<SurveyDefinition>();
+        Assert.NotNull(created);
+
+        // Backend-generated fields
+        Assert.NotEqual(Guid.Empty, created.Id);
+        Assert.True(created.CreatedAt > DateTime.UtcNow.AddMinutes(-1));
+
+        // Mapped fields
+        Assert.Equal(newSurvey.Title, created.Title);
+        Assert.Equal(newSurvey.Description, created.Description);
+        Assert.Equal(newSurvey.QuestionIds, created.QuestionIds);
+
+        // Verify repository was called
+        mockRepo.Verify(r => r.Insert(It.IsAny<SurveyDefinition>()), Times.Once);
     }
 }

--- a/FormFlow.Backend/Endpoints/SurveyEndpoints.cs
+++ b/FormFlow.Backend/Endpoints/SurveyEndpoints.cs
@@ -46,12 +46,12 @@ namespace FormFlow.Backend.Endpoints
             {
                 if (string.IsNullOrWhiteSpace(dto.Title) || string.IsNullOrWhiteSpace(dto.Description))
                 {
-                    return Results.BadRequest(new { error = "Title is required. "});
+                    return Results.BadRequest(new { error = "Title is required. " });
                 }
 
                 if (dto.QuestionIds == null || dto.QuestionIds.Count == 0)
                 {
-                    return Results.BadRequest(new { error = "At least one question is required. "});
+                    return Results.BadRequest(new { error = "At least one question is required. " });
                 }
 
                 var survey = new SurveyDefinition

--- a/FormFlow.Backend/Endpoints/SurveyEndpoints.cs
+++ b/FormFlow.Backend/Endpoints/SurveyEndpoints.cs
@@ -1,5 +1,7 @@
 using FormFlow.Data.Models;
 using FormFlow.Backend.Repositories;
+using System.Text.RegularExpressions;
+using System.Runtime.CompilerServices;
 
 namespace FormFlow.Backend.Endpoints
 {
@@ -39,6 +41,35 @@ namespace FormFlow.Backend.Endpoints
             .Produces<SurveyDefinition>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status404NotFound);
+
+            app.MapPost("/api/surveys", (NewSurvey dto, ISurveyRepository repo) =>
+            {
+                if (string.IsNullOrWhiteSpace(dto.Title) || string.IsNullOrWhiteSpace(dto.Description))
+                {
+                    return Results.BadRequest(new { error = "Title is required. "});
+                }
+
+                if (dto.QuestionIds == null || dto.QuestionIds.Count == 0)
+                {
+                    return Results.BadRequest(new { error = "At least one question is required. "});
+                }
+
+                var survey = new SurveyDefinition
+                {
+                    Id = Guid.NewGuid(),
+                    Title = dto.Title,
+                    Description = dto.Description,
+                    QuestionIds = dto.QuestionIds,
+                    CreatedAt = DateTime.UtcNow
+                };
+
+                repo.Insert(survey);
+
+                return Results.Created($"/api/surveys/{survey.Id}", survey);
+            })
+            .WithName("CreateSurvey")
+            .Produces<SurveyDefinition>(StatusCodes.Status201Created)
+            .Produces(StatusCodes.Status400BadRequest);
         }
     }
 }

--- a/FormFlow.Backend/Repositories/SurveyRepository.cs
+++ b/FormFlow.Backend/Repositories/SurveyRepository.cs
@@ -13,10 +13,18 @@ namespace FormFlow.Backend.Repositories
 
             Surveys.EnsureIndex(s => s.Id, true);
         }
+
+        public SurveyDefinition Insert(SurveyDefinition survey)
+        {
+            Surveys.Insert(survey);
+            return survey;
+        }
     }
 
     public interface ISurveyRepository
     {
         ILiteCollection<SurveyDefinition> Surveys { get; }
+
+        SurveyDefinition Insert(SurveyDefinition survey);
     }
 }

--- a/FormFlow.Data/Models/NewSurvey.cs
+++ b/FormFlow.Data/Models/NewSurvey.cs
@@ -4,14 +4,9 @@ namespace FormFlow.Data.Models
 {
     public class NewSurvey
     {
-        [BsonId]
-        public Guid Id { get; set; }
-
         public string Title { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
         public List<Guid> QuestionIds { get; set; } = [];
-        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-
-        public int? Version { get; set; }
+        //public int? Version { get; set; }
     }
 }

--- a/FormFlow.Data/Models/SurveyDefinition.cs
+++ b/FormFlow.Data/Models/SurveyDefinition.cs
@@ -11,7 +11,6 @@ namespace FormFlow.Data.Models
         public required string Description { get; set; }
         public required List<Guid> QuestionIds { get; set; }
         public required DateTime CreatedAt { get; set; }
-
-        public int? Version { get; set; }
+        //public int? Version { get; set; }
     }
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -34,9 +34,9 @@ Creates a new question and uses `QuestionRepository.cs` to insert into `LiteDb`
 
 ## GET `/api/questions`
 
-This endpoint uses `QuestionRepository.cs` to find all the questions in the `questions` collection. 
-It then produces a list of all the questions in the database. 
----
+This endpoint uses `QuestionRepository.cs` to find all the questions in the `questions` collection.
+It then produces a list of all the questions in the database.
+-------------------------------------------------------------
 
 # **Survey Endpoints**
 
@@ -51,6 +51,7 @@ Returns a list of all saved surveys.
 
 **200 OK**
 **Response Body**
+
 ```json
 [
   {
@@ -74,9 +75,9 @@ Retrieve a single survey by its ID.
 
 **Parameters**
 
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `id` | path | string (uuid) | Yes | The survey’s unique identifier |
+| Name   | In   | Type          | Required | Description                     |
+| ------ | ---- | ------------- | -------- | ------------------------------- |
+| `id` | path | string (uuid) | Yes      | The survey’s unique identifier |
 
 ---
 
@@ -84,6 +85,7 @@ Retrieve a single survey by its ID.
 
 **200 OK**
 **Response Body**
+
 ```json
 {
   "surveyId": "c1b2e3d4-5678-49ab-9cde-1234567890ab",
@@ -103,6 +105,7 @@ Retrieve a single survey by its ID.
 Returned when the provided ID is not a valid GUID.
 
 **Response Body**
+
 ```json
 {
   "error": "Invalid survey id. Must be a GUID."
@@ -115,6 +118,7 @@ Returned when the provided ID is not a valid GUID.
 Returned when no survey exists with the given ID.
 
 **Response Body**
+
 ```json
 {
   "error": "Survey not found."
@@ -123,3 +127,134 @@ Returned when no survey exists with the given ID.
 
 ---
 
+Absolutely — and now that your POST endpoint behavior is stable and we know exactly how it works, I can generate **clean, professional, API‑ready documentation** for it.
+
+I’ll follow the same structure you’ve been using in your project:
+
+- Endpoint summary
+- Request schema
+- Response schema
+- Status codes
+- Example request
+- Example response
+
+This will drop directly into your `/docs` folder or your API.md.
+
+---
+
+## **POST /api/surveys**
+
+**Endpoint**
+
+```
+POST /api/surveys - Create a New Survey
+```
+
+Creates a new survey using the data provided by the client.
+The server generates the survey ID and timestamp.
+
+---
+
+**Request Body (NewSurvey)**
+
+```json
+{
+  "title": "string",
+  "description": "string",
+  "questionIds": ["guid"]
+}
+```
+
+**Field Descriptions**
+
+| Field           | Type           | Required | Description                                      |
+| --------------- | -------------- | -------- | ------------------------------------------------ |
+| `title`       | string         | yes      | The title of the survey.                         |
+| `description` | string         | yes      | A short description of the survey’s purpose.    |
+| `questionIds` | array of GUIDs | yes      | The list of question IDs included in the survey. |
+
+---
+
+**Response Body (SurveyDefinition)**
+
+```json
+{
+  "id": "guid",
+  "title": "string",
+  "description": "string",
+  "questionIds": ["guid"],
+  "createdAt": "2024-01-01T00:00:00Z"
+}
+```
+
+**Field Descriptions**
+
+| Field           | Type           | Description                                         |
+| --------------- | -------------- | --------------------------------------------------- |
+| `id`          | GUID           | Server‑generated unique identifier for the survey. |
+| `title`       | string         | Title of the survey.                                |
+| `description` | string         | Description of the survey.                          |
+| `questionIds` | array of GUIDs | IDs of questions included in the survey.            |
+| `createdAt`   | datetime       | Server‑generated timestamp of creation.            |
+
+---
+
+**Status Codes**
+
+| Code                                | Meaning                                                                |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| **201 Created**               | Survey successfully created. Response includes the full survey object. |
+| **400 Bad Request**           | Invalid input (e.g., malformed JSON, missing required fields).         |
+| **500 Internal Server Error** | Unexpected server error.                                               |
+
+---
+
+**Example Request**
+
+```http
+POST /api/surveys
+Content-Type: application/json
+
+{
+  "title": "Employee Satisfaction Survey",
+  "description": "Quarterly feedback survey",
+  "questionIds": [
+    "c1f6d9c3-4b8e-4c1f-9e1f-2a1a1b1c1d1e",
+    "b2e7f0a4-5c9f-4d2f-8e2f-3b2b2c2d2e2f"
+  ]
+}
+```
+
+---
+
+**Example Response (201 Created)**
+
+```http
+HTTP/1.1 201 Created
+Location: /api/surveys/7f3c2a1b-9d4e-4c2f-8b1e-123456789abc
+Content-Type: application/json
+
+{
+  "id": "7f3c2a1b-9d4e-4c2f-8b1e-123456789abc",
+  "title": "Employee Satisfaction Survey",
+  "description": "Quarterly feedback survey",
+  "questionIds": [
+    "c1f6d9c3-4b8e-4c1f-9e1f-2a1a1b1c1d1e",
+    "b2e7f0a4-5c9f-4d2f-8e2f-3b2b2c2d2e2f"
+  ],
+  "createdAt": "2024-01-01T14:23:11.123Z"
+}
+```
+
+---
+
+**Behavior Summary**
+
+- The client provides only editable fields (`title`, `description`, `questionIds`).
+- The server generates:
+  - `id`
+  - `createdAt`
+- The repository’s `Insert()` method is called to persist the survey.
+- The endpoint returns **201 Created** with the full survey object.
+
+---

--- a/docs/api.md
+++ b/docs/api.md
@@ -127,20 +127,6 @@ Returned when no survey exists with the given ID.
 
 ---
 
-Absolutely — and now that your POST endpoint behavior is stable and we know exactly how it works, I can generate **clean, professional, API‑ready documentation** for it.
-
-I’ll follow the same structure you’ve been using in your project:
-
-- Endpoint summary
-- Request schema
-- Response schema
-- Status codes
-- Example request
-- Example response
-
-This will drop directly into your `/docs` folder or your API.md.
-
----
 
 ## **POST /api/surveys**
 


### PR DESCRIPTION
# Pull Request

## Description
Implemented POST surveys endpoint for creating a new survey. Creates a new survey using the data provided by the client.
The server generates the survey ID and timestamp.

## Related Issues
Closes #107 

## Checklist
- [x] Tests added/updated
<img width="946" height="930" alt="post surveys" src="https://github.com/user-attachments/assets/91ef3475-a1f4-4be7-9a4f-c2f2a75e40f1" />
<img width="1431" height="340" alt="tests passed" src="https://github.com/user-attachments/assets/1a39bbee-7023-430c-9450-abbdf8a63b6d" />

- [x] Documentation updated
`docs/api.md`

- [x] Linting passes